### PR TITLE
docs: fix language reference inconsistency in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Lisp-Go Development Guide
 
-Based on the book <https://buildyourownlisp.com/contents>, implementing a LISP interpreter in C.
+Based on the book <https://buildyourownlisp.com/contents>, implementing a LISP interpreter in Go.
 
 ## Quick Commands
 

--- a/tmp_backup/cmd/lispg/main.go
+++ b/tmp_backup/cmd/lispg/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Lisp-Go interpreter starting...")
-}


### PR DESCRIPTION
- Change 'implementing a LISP interpreter in C' to 'in Go'
- Remove leftover tmp_backup file that should be ignored

The documentation now correctly reflects that this project implements a LISP interpreter in Go, not C, while following the C-based book as reference.